### PR TITLE
feat: add a solution called from_into_box_error

### DIFF
--- a/exercises/conversions/from_str.rs_/from_into_box_error.rs
+++ b/exercises/conversions/from_str.rs_/from_into_box_error.rs
@@ -1,0 +1,100 @@
+// This does practically the same thing that TryFrom<&str> does.
+// Additionally, upon implementing FromStr, you can use the `parse` method
+// on strings to generate an object of the implementor type.
+// You can read more about it at https://doc.rust-lang.org/std/str/trait.FromStr.html
+use std::error;
+use std::str::FromStr;
+#[derive(Debug)]
+struct Person {
+    name: String,
+    age: usize,
+}
+
+// Steps:
+// 1. If the length of the provided string is 0, an error should be returned
+// 2. Split the given string on the commas present in it
+// 3. Only 2 elements should be returned from the split, otherwise return an error
+// 4. Extract the first element from the split operation and use it as the name
+// 5. Extract the other element from the split operation and parse it into a `usize` as the age
+//    with something like `"4".parse::<usize>()`
+// 6. If while extracting the name and the age something goes wrong, an error should be returned
+// If everything goes well, then return a Result of a Person object
+
+impl FromStr for Person {
+    type Err = Box<dyn error::Error>;
+    fn from_str(s: &str) -> Result<Person, Self::Err> {
+        let split = s.split(",").collect::<Vec<&str>>();
+        match split[..] {
+            [name, age] if !name.is_empty() => age
+                .parse::<usize>()
+                .map(|age| Self {
+                    name: name.to_string(),
+                    age,
+                })
+                .map_err(|_| From::from("Failed")),
+            _ => Err(From::from("Invalid input")),
+        }
+    }
+}
+
+fn main() {
+    let p = "Mark,20".parse::<Person>().unwrap();
+    println!("{:?}", p);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn empty_input() {
+        assert!("".parse::<Person>().is_err());
+    }
+    #[test]
+    fn good_input() {
+        let p = "John,32".parse::<Person>();
+        assert!(p.is_ok());
+        let p = p.unwrap();
+        assert_eq!(p.name, "John");
+        assert_eq!(p.age, 32);
+    }
+    #[test]
+    fn missing_age() {
+        assert!("John,".parse::<Person>().is_err());
+    }
+
+    #[test]
+    fn invalid_age() {
+        assert!("John,twenty".parse::<Person>().is_err());
+    }
+
+    #[test]
+    fn missing_comma_and_age() {
+        assert!("John".parse::<Person>().is_err());
+    }
+
+    #[test]
+    fn missing_name() {
+        assert!(",1".parse::<Person>().is_err());
+    }
+
+    #[test]
+    fn missing_name_and_age() {
+        assert!(",".parse::<Person>().is_err());
+    }
+
+    #[test]
+    fn missing_name_and_invalid_age() {
+        assert!(",one".parse::<Person>().is_err());
+    }
+
+    #[test]
+    fn trailing_comma() {
+        assert!("John,32,".parse::<Person>().is_err());
+    }
+
+    #[test]
+    fn trailing_comma_and_some_string() {
+        assert!("John,32,man".parse::<Person>().is_err());
+    }
+}


### PR DESCRIPTION
## Motivation

Because the hint of `from_str` exercise mentioned:
> The implementation of FromStr should return an Ok with a Person object,
or an Err with an error if the string is not valid.
This is almost like the `try_from_into` exercise.
>
>If you're having trouble with returning the correct error type, see the
hints for try_from_into.

So I tend to return the correct error type without changing the `type Err = Box<dyn error::Error>;` line of code.
